### PR TITLE
Update CI Node image to 20 LTS and align react-test-renderer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build_and_test:
     docker:
-      - image: cimg/node:17.2.0
+      - image: cimg/node:20.20.2
     steps:
       - checkout
       - node/install-packages:
@@ -23,7 +23,7 @@ jobs:
             - .
   deploy: # this can be any name you choose
     docker:
-      - image: cimg/node:17.2.0
+      - image: cimg/node:20.20.2
     steps:
       - attach_workspace:
           at: ~/project

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "jest-junit": "^10.0.0",
-    "react-test-renderer": "^17.0.1"
+    "react-test-renderer": "^16.13.1"
   },
   "jest-junit": {
     "suiteName": "jest tests",


### PR DESCRIPTION
Updates the project to a current Node LTS and aligns a test dependency:

- Bump the CI image from `cimg/node:17.2.0` (EOL) to `cimg/node:20.20.2` (active LTS) in both jobs.
- Align `react-test-renderer` to `^16.13.1` to match `react ^16.13.1`, resolving an npm peer-dependency conflict (`react-test-renderer` is imported in `src/App.test.js`).

Verified: `yarn` and `npm` `install` / `test` / `build` all pass on Node 20.20.2.