### PR TITLE
Disable Jest watch mode in test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "export NODE_OPTIONS=--openssl-legacy-provider; react-scripts build",
-    "test": "react-scripts test --maxWorkers=2 --ci --coverage --reporters=default --reporters=jest-junit",
+    "test": "react-scripts test --watchAll=false --maxWorkers=2 --ci --coverage --reporters=default --reporters=jest-junit",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
Adds `--watchAll=false` to the `test` script so `npm test` runs once and exits instead of dropping into interactive watch mode in non-CI environments. CircleCI runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)